### PR TITLE
feat: add cluster URL obfuscation for enhanced security

### DIFF
--- a/cmd/lazyoc/main.go
+++ b/cmd/lazyoc/main.go
@@ -23,6 +23,7 @@ func main() {
 	var noAltScreen bool
 	var kubeconfigPath string
 	var mouseSupport bool
+	var showFullClusterInfo bool
 
 	rootCmd := &cobra.Command{
 		Use:   "lazyoc",
@@ -33,7 +34,7 @@ It provides an intuitive, vim-like interface for viewing and managing cluster re
 Press ? for help once inside the application.`,
 		Version: fmt.Sprintf("%s (commit: %s, built: %s)", version, commit, date),
 		Run: func(cmd *cobra.Command, args []string) {
-			runTUI(debugMode, !noAltScreen, kubeconfigPath, mouseSupport)
+			runTUI(debugMode, !noAltScreen, kubeconfigPath, mouseSupport, showFullClusterInfo)
 		},
 	}
 
@@ -43,6 +44,7 @@ Press ? for help once inside the application.`,
 	rootCmd.Flags().BoolVar(&noAltScreen, "no-alt-screen", false, "Disable alternate screen buffer")
 	rootCmd.Flags().StringVar(&kubeconfigPath, "kubeconfig", "", "Path to kubeconfig file (defaults to $HOME/.kube/config)")
 	rootCmd.Flags().BoolVar(&mouseSupport, "mouse", true, "Enable mouse support (click tabs, select resources, scroll)")
+	rootCmd.Flags().BoolVar(&showFullClusterInfo, "show-full-cluster-info", false, "Show full cluster URLs without obfuscation (security risk)")
 
 	if err := rootCmd.ExecuteContext(ctx); err != nil {
 		log.Fatalf("Error executing command: %v", err)
@@ -51,13 +53,14 @@ Press ? for help once inside the application.`,
 }
 
 // runTUI starts the terminal user interface
-func runTUI(debug bool, altScreen bool, kubeconfigPath string, mouseSupport bool) {
+func runTUI(debug bool, altScreen bool, kubeconfigPath string, mouseSupport bool, showFullClusterInfo bool) {
 	opts := ui.ProgramOptions{
-		Version:      fmt.Sprintf("%s (commit: %s, built: %s)", version, commit, date),
-		Debug:        debug,
-		AltScreen:    altScreen,
-		MouseSupport: mouseSupport,
-		KubeConfig:   kubeconfigPath,
+		Version:            fmt.Sprintf("%s (commit: %s, built: %s)", version, commit, date),
+		Debug:              debug,
+		AltScreen:          altScreen,
+		MouseSupport:       mouseSupport,
+		KubeConfig:         kubeconfigPath,
+		ShowFullClusterInfo: showFullClusterInfo,
 	}
 
 	if err := ui.RunTUI(opts); err != nil {

--- a/internal/ui/program.go
+++ b/internal/ui/program.go
@@ -7,27 +7,29 @@ import (
 
 // ProgramOptions holds configuration for the Bubble Tea program
 type ProgramOptions struct {
-	Version      string
-	Debug        bool
-	AltScreen    bool
-	MouseSupport bool
-	KubeConfig   string
+	Version             string
+	Debug               bool
+	AltScreen           bool
+	MouseSupport        bool
+	KubeConfig          string
+	ShowFullClusterInfo bool
 }
 
 // DefaultProgramOptions returns sensible defaults for the TUI program
 func DefaultProgramOptions() ProgramOptions {
 	return ProgramOptions{
-		Version:      "dev",
-		Debug:        false,
-		AltScreen:    true,  // Use alternate screen buffer
-		MouseSupport: true,  // Enable mouse support for scrolling
+		Version:             "dev",
+		Debug:               false,
+		AltScreen:           true,  // Use alternate screen buffer
+		MouseSupport:        true,  // Enable mouse support for scrolling
+		ShowFullClusterInfo: false, // Obfuscate cluster info by default for security
 	}
 }
 
 // NewProgram creates a new Bubble Tea program with the TUI model
 func NewProgram(opts ProgramOptions) *tea.Program {
 	// Create the simplified TUI model
-	tui := NewTUI(opts.Version, opts.Debug)
+	tui := NewTUI(opts.Version, opts.Debug, opts.ShowFullClusterInfo)
 
 	// Set kubeconfig if provided
 	if opts.KubeConfig != "" {


### PR DESCRIPTION
## Summary
- Implement cluster URL obfuscation to protect sensitive infrastructure information
- Add configurable security feature with `--show-full-cluster-info` flag
- Prevent accidental exposure of cluster domains in screenshots and demos

## Changes Made
- Added `obfuscateClusterContext()` function that masks sensitive domain parts
- Obfuscates cluster URLs in both header display and log messages
- Keeps first 2 and last 2 characters of long domains, replaces middle with asterisks
- Added `--show-full-cluster-info` CLI flag to disable obfuscation when needed
- Updated TUI initialization to pass obfuscation preference through the system

## Security Benefits
- Protects internal cluster domain names from accidental exposure
- Reduces risk of leaking infrastructure details in public screenshots/demos
- Maintains usability while enhancing privacy
- Configurable behavior for different environments

## Example
- Before: `api-rm3-7wse-p1-openshiftapps-com:6443`
- After: `ap*****************************om:6443`
- With flag: `--show-full-cluster-info` shows full URLs

## Test plan
- [x] Built successfully with `go build`
- [x] Linting passes (`golangci-lint run`)
- [x] All tests pass (`go test ./...`)
- [x] Obfuscation function tested with real cluster URL patterns
- [x] Flag functionality verified in test environment

🤖 Generated with [Claude Code](https://claude.ai/code)